### PR TITLE
fix : .gitignore 프로덕션 빌드 경로 정정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 /coverage
 
 # production
-/build
+/client/build
 
 # misc
 .DS_Store


### PR DESCRIPTION
현 .gitignore 파일에 명시된 production 빌드 경로(`/build`)가 실제 경로(`/client/build`)와 맞지 않아 수정했습니다.